### PR TITLE
Refactored useInterview hooks to allow an undefined id

### DIFF
--- a/src/components/InterviewRunnerView/index.tsx
+++ b/src/components/InterviewRunnerView/index.tsx
@@ -19,14 +19,14 @@ import { buildScriptConfig, InterviewScreenAdapter } from './adapters';
  */
 export default function InterviewRunnerView(): JSX.Element | null {
   const { interviewId } = useParams();
-  const interview = useInterview(interviewId ?? '');
-  const screens = useInterviewScreens(interviewId ?? '');
+  const interview = useInterview(interviewId);
+  const screens = useInterviewScreens(interviewId);
   const [currentScreen, setCurrentScreen] =
     useState<InterviewScreenAdapter | null>(null);
   const [responseConsumer, setResponseConsumer] =
     useState<ResponseConsumer | null>(null);
   const [complete, setComplete] = useState<boolean>(false);
-  const entries = useInterviewScreenEntries(interviewId ?? '');
+  const entries = useInterviewScreenEntries(interviewId);
 
   // Construct and run an interview on component load.
   useEffect(() => {

--- a/src/components/SingleInterviewView/index.tsx
+++ b/src/components/SingleInterviewView/index.tsx
@@ -9,10 +9,10 @@ import Sidebar from './Sidebar';
 
 export default function SingleInterviewView(): JSX.Element {
   const { interviewId } = useParams();
-  const interview = useInterview(interviewId ?? '');
-  const screens = useInterviewScreens(interview?.id ?? '');
-  const entries = useInterviewScreenEntries(interview?.id ?? '');
-  const actions = useInterviewConditionalActions(interview?.id ?? '');
+  const interview = useInterview(interviewId);
+  const screens = useInterviewScreens(interview?.id);
+  const entries = useInterviewScreenEntries(interview?.id);
+  const actions = useInterviewConditionalActions(interview?.id);
 
   if (interview === undefined) {
     return <p>Could not find interview</p>;

--- a/src/hooks/useInterview.ts
+++ b/src/hooks/useInterview.ts
@@ -13,14 +13,16 @@ import useInterviewStore from './useInterviewStore';
  * @returns {Interview.T | undefined} The interview, or undefined if the
  * interview couldn't be found.
  */
-export default function useInterview(id: string): Interview.T | undefined {
+export default function useInterview(
+  id: string | undefined,
+): Interview.T | undefined {
   const dispatch = useAppDispatch();
   const interviewStore = useInterviewStore();
   const { loadedInterviews } = useAppState();
 
   // load interview from backend
   const interviewFromStorage = useLiveQuery(
-    () => interviewStore.getInterview(id),
+    () => (id === undefined ? undefined : interviewStore.getInterview(id)),
     [id],
   );
 
@@ -37,5 +39,5 @@ export default function useInterview(id: string): Interview.T | undefined {
 
   // load the interview from global state (which should be up-to-date with
   // whatever is in storage)
-  return loadedInterviews.get(id);
+  return id === undefined ? undefined : loadedInterviews.get(id);
 }

--- a/src/hooks/useInterviewConditionalActions.ts
+++ b/src/hooks/useInterviewConditionalActions.ts
@@ -19,7 +19,7 @@ import useInterviewStore from './useInterviewStore';
  * Or undefined if the interview could not be found.
  */
 export default function useInterviewConditionalActions(
-  interviewId: string,
+  interviewId: string | undefined,
 ): Map<string, ConditionalAction.T[]> | undefined {
   const dispatch = useAppDispatch();
   const interviewStore = useInterviewStore();
@@ -28,7 +28,10 @@ export default function useInterviewConditionalActions(
 
   // load conditional actions from backend
   const conditionalActionsFromStorage = useLiveQuery(
-    () => interviewStore.getConditionalActionsOfInterview(interviewId),
+    () =>
+      interviewId === undefined
+        ? undefined
+        : interviewStore.getConditionalActionsOfInterview(interviewId),
     [interviewId],
   );
 
@@ -59,5 +62,5 @@ export default function useInterviewConditionalActions(
     return undefined;
   }, [screens, loadedConditionalActions]);
 
-  return screensToActionsMap;
+  return interviewId === undefined ? undefined : screensToActionsMap;
 }

--- a/src/hooks/useInterviewScreenEntries.ts
+++ b/src/hooks/useInterviewScreenEntries.ts
@@ -19,7 +19,7 @@ import useInterviewStore from './useInterviewStore';
  * entries. Or undefined if the interview could not be found.
  */
 export default function useInterviewScreenEntries(
-  interviewId: string,
+  interviewId: string | undefined,
 ): Map<string, InterviewScreenEntry.T[]> | undefined {
   const dispatch = useAppDispatch();
   const interviewStore = useInterviewStore();
@@ -28,7 +28,10 @@ export default function useInterviewScreenEntries(
 
   // load screen entries from backend
   const screenEntriesFromStorage = useLiveQuery(
-    () => interviewStore.getScreenEntriesOfInterview(interviewId),
+    () =>
+      interviewId === undefined
+        ? undefined
+        : interviewStore.getScreenEntriesOfInterview(interviewId),
     [interviewId],
   );
 
@@ -59,5 +62,5 @@ export default function useInterviewScreenEntries(
     return undefined;
   }, [screens, loadedInterviewScreenEntries]);
 
-  return screensToEntriesMap;
+  return interviewId === undefined ? undefined : screensToEntriesMap;
 }

--- a/src/hooks/useInterviewScreens.ts
+++ b/src/hooks/useInterviewScreens.ts
@@ -16,7 +16,7 @@ import useInterviewStore from './useInterviewStore';
  * undefined if the interview could not be found.
  */
 export default function useInterviewScreens(
-  interviewId: string,
+  interviewId: string | undefined,
 ): InterviewScreen.T[] | undefined {
   const dispatch = useAppDispatch();
   const interviewStore = useInterviewStore();
@@ -25,7 +25,10 @@ export default function useInterviewScreens(
 
   // load interview screens from backend
   const screensFromStorage = useLiveQuery(
-    () => interviewStore.getScreensOfInterview(interviewId),
+    () =>
+      interviewId === undefined
+        ? undefined
+        : interviewStore.getScreensOfInterview(interviewId),
     [interviewId],
   );
 
@@ -48,5 +51,5 @@ export default function useInterviewScreens(
     [interview, loadedInterviewScreens],
   );
 
-  return screens;
+  return interviewId === undefined ? undefined : screens;
 }


### PR DESCRIPTION
Allows `interviewId` to be `undefined` in useInterview-related hooks.

The reason for this change is because these hooks are used when it's time to load interview-related information and the interviewId usually comes from the URL params. Extracting an id from URL params defaults to a type of `string | undefined`, so it's a better developer experience to allow these hooks to expect a potential undefined value.

@iebaker tagging you on this since you said you were curious to see how to handle this case!

Because hooks can't be run conditionally, we still run all the necessary useEffect hooks. But before doing any API calls, we check if the interview id is undefined. If it is, then we don't waste time with the API call. So we work around the "no hooks in conditional logic" rule by adding our conditional logic _inside_ the hook