### PR TITLE
Allow empty constructor and simplify import order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,11 +5,13 @@
       "jsx": true
     },
     "ecmaVersion": 13,
+    "project": "tsconfig.json",
     "sourceType": "module"
   },
   "extends": [
     "eslint:recommended",
     "airbnb",
+    "airbnb-typescript",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:import/recommended",
@@ -77,18 +79,10 @@
       "error",
       {
         "alphabetize": {
-          "order": "asc",
-          "caseInsensitive": false
+          "order": "ignore",
+          "caseInsensitive": true
         },
-        "groups": [
-          "builtin",
-          "external",
-          "internal",
-          "parent",
-          "sibling",
-          "object",
-          "type"
-        ],
+        "groups": [["builtin", "external"], "internal", "type"],
         "newlines-between": "never"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@typescript-eslint/parser": "^5.23.0",
     "eslint": "^8.15.0",
     "eslint-config-airbnb": "^19.0.4",
+    "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",

--- a/src/components/InterviewRunnerView/adapters.ts
+++ b/src/components/InterviewRunnerView/adapters.ts
@@ -9,7 +9,6 @@ import { ScriptConfigSchema } from '../../script/ScriptConfigSchema';
  * Attaches getter method necessary for ConfigurableScript to InterviewScreen.T type.
  */
 export class InterviewScreenAdapter {
-  // eslint-disable-next-line
   constructor(private interviewScreen: InterviewScreen.T) {}
 
   getId(): string {

--- a/src/components/InterviewRunnerView/index.tsx
+++ b/src/components/InterviewRunnerView/index.tsx
@@ -5,6 +5,7 @@ import {
 } from '@dataclinic/interview';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { buildScriptConfig, InterviewScreenAdapter } from './adapters';
 import useInterview from '../../hooks/useInterview';
 import useInterviewScreenEntries from '../../hooks/useInterviewScreenEntries';
 import useInterviewScreens from '../../hooks/useInterviewScreens';
@@ -12,7 +13,6 @@ import * as InterviewScreenEntry from '../../models/InterviewScreenEntry';
 import ConfigurableScript from '../../script/ConfigurableScript';
 import { ScriptConfigSchema } from '../../script/ScriptConfigSchema';
 import Button from '../ui/Button';
-import { buildScriptConfig, InterviewScreenAdapter } from './adapters';
 
 /**
  * Runs an interview based on the ID of the interview in the URL params.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4193,6 +4193,13 @@ eslint-config-airbnb-base@^15.0.0:
     object.entries "^1.1.5"
     semver "^6.3.0"
 
+eslint-config-airbnb-typescript@^17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.0.0.tgz#360dbcf810b26bbcf2ff716198465775f1c49a07"
+  integrity sha512-elNiuzD0kPAPTXjFWg+lE24nMdHMtuxgYoD30OyMD6yrW1AhFZPAg27VX7d3tzOErw+dgJTNWfRSDqEcXb4V0g==
+  dependencies:
+    eslint-config-airbnb-base "^15.0.0"
+
 eslint-config-airbnb@^19.0.4:
   version "19.0.4"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz#84d4c3490ad70a0ffa571138ebcdea6ab085fdc3"


### PR DESCRIPTION
- Adds the `eslint-config-airbnb-typescript` plugin which fixes the issue of valid empty constructors in typescript
- Simplifies the import lint rules to no longer enforce an alphabetical order.
- The import groups have also been hugely simplified. We still expect some basic grouping of imports, but now there are only 3 groups: external libraries at the top, then everything else, and finally type imports (with `import type`) at the end. This is a significantly simplified version of the default order eslint recomments: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md
And again, no more alphabetic sorting within the groups, so that should make life way easier.