### PR TITLE
add ag-grid to display airtable search responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@types/react-dom": "^18.0.6",
     "@types/react-scroll": "^1.8.4",
     "@types/styled-components": "^5.1.25",
+    "ag-grid-community": "^28.2.1",
+    "ag-grid-react": "^28.2.1",
     "classnames": "^2.3.1",
     "dexie": "^3.2.2",
     "dexie-react-hooks": "^1.1.1",

--- a/src/components/InterviewRunnerView/InterviewRunnerEntry.tsx
+++ b/src/components/InterviewRunnerView/InterviewRunnerEntry.tsx
@@ -1,3 +1,6 @@
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import { useEffect, useState } from 'react';
 import Form from '../ui/Form';
 import InputText from '../ui/InputText';
 import * as InterviewScreenEntry from '../../models/InterviewScreenEntry';
@@ -29,6 +32,27 @@ export default function InterviewRunnerEntry({ entry }: Props): JSX.Element {
     airtableQuery,
     entry.responseTypeOptions,
   );
+
+  // const gridRef = useRef();
+  const [rowData, setRowData] = useState();
+  const [columnDefs, setColumnDefs] = useState<Array<Record<string, string>>>();
+
+  useEffect(() => {
+    if (!responseData || responseData.length < 1) return;
+    // TODO - get superset of all fields returned
+    setColumnDefs(
+      Object.keys(responseData[0].fields).map(f => ({
+        field: f,
+      })),
+    );
+
+    setRowData(
+      responseData.map((d: any) => ({
+        id: d.id,
+        ...d.fields,
+      })),
+    );
+  }, [responseData]);
 
   switch (entry.responseType) {
     case InterviewScreenEntry.ResponseType.TEXT:
@@ -85,20 +109,22 @@ export default function InterviewRunnerEntry({ entry }: Props): JSX.Element {
           {isSuccess &&
             typeof responseData !== 'string' &&
             responseData.length > 0 && (
-              <Form.Dropdown
-                key={entry.id}
-                name={entry.responseKey}
-                label={entry.prompt}
-                placeholder={isLoading ? 'Loading...' : 'Select a record...'}
-                options={
-                  isSuccess
-                    ? responseData.map((d: any) => ({
-                        value: d.id, // TODO -  need to include selected base / table IDs
-                        displayValue: JSON.stringify(d.fields),
-                      }))
-                    : []
-                }
-              />
+              <>
+                <strong>{entry.prompt}</strong>
+                <div
+                  className="ag-theme-alpine"
+                  style={{ width: '100%', height: 250 }}
+                >
+                  <AgGridReact
+                    // TODO - handle row selection
+                    onRowClicked={e => console.log(e)}
+                    onRowDoubleClicked={e => console.log(e)}
+                    rowSelection="single"
+                    rowData={rowData}
+                    columnDefs={columnDefs}
+                  />
+                </div>
+              </>
             )}
           {isSuccess &&
             typeof responseData !== 'string' &&


### PR DESCRIPTION
This:
- adds ag-grid 
- uses ag-grid to show responses returned from Airtable API

This does not: 
- handle selection of items on the grid, those functions are to be completed 




https://user-images.githubusercontent.com/444765/204928475-e47174e2-3e26-41c9-a025-aaba2873cb5c.mov

