### PR TITLE
Add support for partial searches in Airtable

### DIFF
--- a/src/hooks/useAirtableQuery.ts
+++ b/src/hooks/useAirtableQuery.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { ResponseTypeOptions } from '../models/InterviewScreenEntry';
-import getEnvConfig, { EnvVar } from '../util/getEnvConfig';
 
 /**
  * Hook to access Airtable Records API
@@ -25,13 +24,15 @@ export default function useAirtableQuery(
     queryFn: async () => {
       // fetch all based on Base and Table
       if (queryString) {
-        // TODO - enable searching on multiple fields, not just first one
-        const airtableQueryURL = encodeURI(
-          `${getEnvConfig(EnvVar.APIBaseURL) ?? '//'}/airtable-records/${
-            queryOptions.selectedTable
-          }?${queryOptions.selectedFields[0]}=${queryString}`,
+        const { selectedFields, selectedTable } = queryOptions;
+        const searchParams = new URLSearchParams();
+        selectedFields.forEach(field => {
+          searchParams.append(field, queryString);
+        });
+
+        const res = await fetch(
+          `/airtable-records/${selectedTable}?${searchParams.toString()}`,
         );
-        const res = await fetch(airtableQueryURL);
         return res.json();
       }
       return [];

--- a/src/util/getEnvConfig.ts
+++ b/src/util/getEnvConfig.ts
@@ -1,5 +1,4 @@
 export enum EnvVar {
-  APIBaseURL = 'REACT_APP_INTERVIEW_APP_API_BASE_URL',
   AirtableConfigJSON = 'REACT_APP_AIRTABLE_CONFIG_JSON',
 }
 /**


### PR DESCRIPTION
- Added support for passing multiple query params in `useAirtableQuery`
- Removed need for `REACT_APP_INTERVIEW_APP_API_BASE_URL` env var
- Changed `search_record` in Airtable API class to now use `FIND` which supports partial string matching rather than using the exact `match` formula