### PR TITLE
Fix bug where forms refs are not cleaned up when components unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@reach/dialog": "^0.17.0",
     "@reach/listbox": "^0.17.0",
     "@reach/visually-hidden": "^0.17.0",
-    "@react-aria/utils": "^3.14.0",
     "@tanstack/react-query": "^4.18.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",

--- a/src/components/SingleInterviewView/ScreenPage.tsx
+++ b/src/components/SingleInterviewView/ScreenPage.tsx
@@ -148,10 +148,12 @@ export default function ScreenCard({
   }, [allActions, screen, interviewService, allEntries, dispatch, toaster]);
 
   function formRefSetter(formKey: string): React.RefCallback<HTMLFormElement> {
-    return (formElt: HTMLFormElement) => {
+    return (formElt: HTMLFormElement | null) => {
       if (formElt) {
         allFormRefs.current.set(formKey, formElt);
       } else {
+        // `formElt` is null when the component unmounts, so that's when we
+        // should remove this from the `allFormRefs` map
         allFormRefs.current.delete(formKey);
       }
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,13 +1088,6 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.6.2":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.1.tgz#1148bb33ab252b165a06698fde7576092a78b4a9"
-  integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
-  dependencies:
-    regenerator-runtime "^0.13.10"
-
 "@babel/template@^7.18.10", "@babel/template@^7.18.6", "@babel/template@^7.3.3":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -2136,36 +2129,6 @@
   dependencies:
     prop-types "^15.7.2"
     tslib "^2.3.0"
-
-"@react-aria/ssr@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.3.0.tgz#25e81daf0c7a270a4a891159d8d984578e4512d8"
-  integrity sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-
-"@react-aria/utils@^3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.14.0.tgz#87877e89e959c8b6299da953ec3a7167de2192c3"
-  integrity sha512-DHgmwNBNEhnb6DEYYAfbt99wprBqJJOBBeIpQ2g3+pxwlw4BZ+v4Qr+rDD0ZibWV0mYzt8zOhZ9StpId7iTF0Q==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/ssr" "^3.3.0"
-    "@react-stately/utils" "^3.5.1"
-    "@react-types/shared" "^3.15.0"
-    clsx "^1.1.1"
-
-"@react-stately/utils@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.5.1.tgz#502de762e5d33e892347c5f58053674e06d3bc92"
-  integrity sha512-INeQ5Er2Jm+db8Py4upKBtgfzp3UYgwXYmbU/XJn49Xw27ktuimH9e37qP3bgHaReb5L3g8IrGs38tJUpnGPHA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-
-"@react-types/shared@^3.15.0":
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.15.0.tgz#a4a78f36bc8daaefe6e9a9df1f453271639c2233"
-  integrity sha512-hwuE4BmgswqP+HRDSLMj7DcnYOCCK+ZRuKnc9AVhXS4LBrwRSkdUkNvXhgvqF5tav7IqTpG9pBYMR9wedehuhA==
 
 "@remix-run/router@1.0.4":
   version "1.0.4"
@@ -3771,11 +3734,6 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
-
-clsx@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
-  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -8441,11 +8399,6 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
-
-regenerator-runtime@^0.13.10:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
-  integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==
 
 regenerator-runtime@^0.13.11:
   version "0.13.11"


### PR DESCRIPTION
The issue was that our Form UI components rely on merging refs. Merging refs is best done using a callback ref, but some libraries (such as react-aria) require an object ref in order to work properly. So to work around this we use a callback ref to merge refs and then use react-spectrum's util `useObjectRef` to turn the callback ref to an object ref. The problem is that `useObjectRef` has a few issues which breaks the invariants of how a ref should behave:
1. Refs should only get called on mount and unmount. Instead, by being placed in a `useLayoutEffect` function it gets called every time the function is recreated.
2. Refs should get called with a `null` value when the component unmounts. `useObjectRef` breaks this invariant because it doesn't include a cleanup function to call the callback ref with `null`

The 2nd point is what was causing our forms to break. We wrote our callback ref to expect a cleanup function by unsetting a form ref when `null` is received. But because of `useObjectRef`, the cleanup never happens.

This PR fixes things by using an object ref that overrides the getter and setter methods to keep the `current` value in sync with the callback ref. This means when the object ref is set to `null` by React, the callback ref will be called with `null` as well.