### PR TITLE
make HelperText display for airtable query entries

### DIFF
--- a/src/components/InterviewRunnerView/InterviewRunnerEntry.tsx
+++ b/src/components/InterviewRunnerView/InterviewRunnerEntry.tsx
@@ -141,7 +141,11 @@ export default function InterviewRunnerEntry({
     case InterviewScreenEntry.ResponseType.AIRTABLE:
       return (
         <div>
-          <strong>{entryPrompt}</strong>
+          <div className="pb-4">
+            <strong>{entryPrompt}</strong>
+            <br />
+            <text>{entryHelperText}</text>
+          </div>
           <LabelWrapper label="Search for record">
             <InputText
               required


### PR DESCRIPTION
fixes #224 

![helperText](https://user-images.githubusercontent.com/23040492/229915812-b6d118d9-1d6d-4d26-abcf-108c918493b1.png)
